### PR TITLE
Release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ tf_ghe_server CHANGELOG
 
 This file is used to list changes made in each version of the tf_ghe_server Terraform plan.
 
+v1.1.0 (2016-05-02)
+-------------------
+- [Brian Menges] - Added `volume_size` and `volume_type` specifications and `root_` variables for mentioned tunables to instance deployted
+- [Brian Menges] - Set default `root_volume_size` to 20 GB
+- [Brian Menges] - Set default `root_volume_type` to `standard`
+- [Brian Menges] - Added Name tag to `root_block_device` of `${var.hostname}.${var.domain} /`
+- [Brian Menges] - NOTE: incompatible with root type `io1`
+
 v1.0.4 (2016-04-20)
 -------------------
 - [Brian Menges] - Updated [ghe-server-creds.tpl](files/ghe-server-creds.tpl), there is no user admin

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ These resources will incur charges on your AWS bill. It is your responsibility t
 * `log_to_file`: Log chef-client to file. Default: `true`
 * `public_ip`: Associate public IP to instance. Default `true`
 * `root_delete_termination`: Delete root device on VM termination. Default: `true`
+* `root_volume_size`: Size of the root volume in GB. Default: `20`
+* `root_volume_type`: Type of root volume. Supports `gp2` and `standard`. Default `standard`
 * `server_count`: Server count. Default: `1`; DO NOT CHANGE!
 * `sgrule_ntp`: Boolean to create security group rule allowing NTP. Default: `0`
 * `sgrule_smtp`: Boolean to create security group rule allowing SMTP. Default: `0`
@@ -100,7 +102,8 @@ ami_map.<aws_region>-<ghe_version> = "value"
 
 Variable `ghe_version` should be one of the following:
 
-* 2.5.4 (default)
+* 2.6.0 (default)
+* 2.5.4
 * 2.5.3
 * 2.5.2
 * 2.5.1
@@ -148,7 +151,7 @@ Please understand that this is a work in progress and is subject to change rapid
 
 ## `CHANGELOG`
 
-Please refer to the [`CHANGELOG.md`](CHANGELOG.md)
+Please refer to the [CHANGELOG.md](CHANGELOG.md)
 
 ## License
 

--- a/main.tf
+++ b/main.tf
@@ -157,6 +157,12 @@ resource "aws_instance" "ghe-server" {
   }
   root_block_device = {
     delete_on_termination = "${var.root_delete_termination}"
+    volume_size = "${var.root_volume_size}"
+    volume_type = "${var.root_volume_type}"
+    tags = {
+      Name        = "${var.hostname}.${var.domain}"
+      Description = "${var.tag_description}"
+    }
   }
   # seperate device for GHE to use at /data
   ebs_block_device {

--- a/variables.tf
+++ b/variables.tf
@@ -163,6 +163,14 @@ variable "root_delete_termination" {
   description = "Delete server root block device on termination"
   default     = true
 }
+variable "root_volume_size" {
+  description = "Size in GB of root device"
+  default     = 20
+}
+variable "root_volume_type" {
+  description = "Type of root volume"
+  default     = "standard"
+}
 variable "server_count" {
   description = "Number of CHEF Servers to provision. DO NOT CHANGE!"
   default = 1


### PR DESCRIPTION
- [Brian Menges] - Added `volume_size` and `volume_type` specifications and `root_` variables for mentioned tunables to instance deployted
- [Brian Menges] - Set default `root_volume_size` to 20 GB
- [Brian Menges] - Set default `root_volume_type` to `standard`
- [Brian Menges] - Added Name tag to `root_block_device` of `${var.hostname}.${var.domain} /`
- [Brian Menges] - NOTE: incompatible with root type `io1`
- [Brian Menges] - Update default GHE version to `2.6.0` in documentation