### PR TITLE
Release v1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ tf_ghe_server CHANGELOG
 
 This file is used to list changes made in each version of the tf_ghe_server Terraform plan.
 
+v1.1.2 (2016-05-03)
+-------------------
+- [Brian Menges] - GHE default root device size >= 60 GB
+
 v1.1.1 (2016-05-02)
 -------------------
 - [Brian Menges] - Remove tags on roob_block_device

--- a/variables.tf
+++ b/variables.tf
@@ -165,7 +165,7 @@ variable "root_delete_termination" {
 }
 variable "root_volume_size" {
   description = "Size in GB of root device"
-  default     = 20
+  default     = 60
 }
 variable "root_volume_type" {
   description = "Type of root volume"


### PR DESCRIPTION
- [Brian Menges] - GHE default root device size >= 60 GB